### PR TITLE
Use bioconda for snakemake related packages only

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: datapkg
 channels:
-  - bioconda # for snakemake
-  - conda-forge # for most other packages
+  - conda-forge
   - defaults
 dependencies:
   - python=3.11
@@ -15,5 +14,5 @@ dependencies:
   - osmium-tool==1.16.0 # openstreetmap extracts
   - pyyaml # read YAML files
   - pyogrio # faster geospatial i/o
-  - snakemake==7.32.4 # workflow management
-  - snakefmt # Snakefile formatting
+  - bioconda::snakemake==7.32.4 # workflow management
+  - bioconda::snakefmt # Snakefile formatting


### PR DESCRIPTION
Previously, with the full range of packages available from `bioconda`, `conda-forge` and `default` channels, `micromamba` failed to solve the environment specification. Removing `bioconda` from the channels list (and including it in the relevant per-dependency listings) enables a solve. Note that retaining `bioconda` in the channels list, but dropping its ranking to below `conda-forge` also enabled a successful solve. Note that packages are duplicated between the channels.

Addresses #4.